### PR TITLE
Rescue ArgumentError exception for oversize floats according to Float.parse/1 doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+* Rescue ArgumentError exception for oversize floats according to Float.parse/1 doc
+
 ## [1.0.0] - 2020-08-21
 
 No changes in this release. We have tested the library on a big bunch of CRDs and feel confident to publish a sable relese.

--- a/lib/ymlr/encoder.ex
+++ b/lib/ymlr/encoder.ex
@@ -134,6 +134,8 @@ defmodule Ymlr.Encoder do
       {_, ""} -> true
       _ -> false
     end
+  rescue
+    _ -> false
   end
 
   defp with_quotes(data) do

--- a/lib/ymlr/encoder_test.exs
+++ b/lib/ymlr/encoder_test.exs
@@ -89,6 +89,11 @@ defmodule Ymlr.EncoderTest do
       assert MUT.to_s!(1.2) == "1.2"
     end
 
+    test "hex and oversize float" do
+      assert MUT.to_s!("7e0981ff4c0daa3a47db5542ad5c167176145ef65f597a7f94ba2f5b41d35718") == "7e0981ff4c0daa3a47db5542ad5c167176145ef65f597a7f94ba2f5b41d35718"
+      assert MUT.to_s!("1.7976931348623157e+309") == "1.7976931348623157e+309"
+    end
+
     test "lists" do
       assert MUT.to_s!([]) == ""
       assert MUT.to_s!([1]) == "- 1"


### PR DESCRIPTION
From Float.parse/1 documentation

> If the size of float exceeds the maximum size of 1.7976931348623157e+308, the ArgumentError exception is raised.

This PR rescues the exception in the is_numeric() function and returns false.