### PR TITLE
Add support for older Elixir versions

### DIFF
--- a/lib/ymlr/encoder.ex
+++ b/lib/ymlr/encoder.ex
@@ -73,10 +73,24 @@ defmodule Ymlr.Encoder do
     "{}"
   end
 
-  defp encode_as_io_list(%Date{} = data, _), do: Calendar.strftime(data, "%Y-%m-%d")
+  defp encode_as_io_list(%Date{} = data, _), do: Calendar.ISO.date_to_string(data.year, data.month, data.day)
 
   defp encode_as_io_list(%DateTime{} = data, _) do
-    data |> DateTime.shift_zone!("Etc/UTC") |> Calendar.strftime("%Y-%m-%d %H:%M:%S.000000000 Z")
+    utc_data = data |> DateTime.shift_zone!("Etc/UTC")
+
+    Calendar.ISO.datetime_to_string(
+      utc_data.year,
+      utc_data.month,
+      utc_data.day,
+      utc_data.hour,
+      utc_data.minute,
+      utc_data.second,
+      utc_data.microsecond,
+      utc_data.time_zone,
+      "UTC",
+      0,
+      0
+    )
   end
 
   defp encode_as_io_list(data, level) when is_map(data) do

--- a/lib/ymlr/encoder_test.exs
+++ b/lib/ymlr/encoder_test.exs
@@ -199,7 +199,7 @@ defmodule Ymlr.EncoderTest do
     end
 
     test "datetime" do
-      assert MUT.to_s!(DateTime.new!(~D[2016-05-24], ~T[13:26:08.003], "Etc/UTC")) == "2016-05-24 13:26:08.000000000 Z"
+      assert MUT.to_s!(DateTime.new!(~D[2016-05-24], ~T[13:26:08.003000000], "Etc/UTC")) == "2016-05-24 13:26:08.003000Z"
     end
   end
 

--- a/lib/ymlr/encoder_test.exs
+++ b/lib/ymlr/encoder_test.exs
@@ -199,7 +199,8 @@ defmodule Ymlr.EncoderTest do
     end
 
     test "datetime" do
-      assert MUT.to_s!(DateTime.new!(~D[2016-05-24], ~T[13:26:08.003000000], "Etc/UTC")) == "2016-05-24 13:26:08.003000Z"
+      {:ok, datetime, _} = DateTime.from_iso8601("2016-05-24T13:26:08,003000Z")
+      assert MUT.to_s!(datetime) == "2016-05-24 13:26:08.003000Z"
     end
   end
 


### PR DESCRIPTION
It turns out that my recent PR with Date and DateTime support broke ymlr on older versions of Elixir.

The PR used ```Calendar.strftime``` that was introduced in Elixir 1.11 and thus was not compatible with older versions of Elixir.

This PR fixes that problem by using function from ```Calendar.ISO``` instead. These functions have been around in Elixir since 1.4.