### PR TITLE
Add an option to encode atoms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,9 @@ k8s-*.tar
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
 
-# Idea files
+# Editor files
 /.idea
+/.vscode
 
 .direnv
 .env

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+
+- Options with `atoms` option, to match `yaml_elixir` library.
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [3.0.1] - 2022-09-05

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ See The usage livebook `usage.livemd` for more detailed examples.
     a: 1
     """
 
+    iex> Ymlr.document!({"comment", %{a: 1, b: :c}}, atoms: true)
+    """
+    ---
+    # comment
+    :a: 1
+    :b: :c
+    """
+
     iex> Ymlr.document!({["comment 1", "comment 2"], %{"a" => "a", "b" => :b, "c" => "true", "d" => "100"}})
     """
     ---
@@ -67,3 +75,7 @@ See The usage livebook `usage.livemd` for more detailed examples.
     b: 2
     """
 ```
+
+### Options
+
+- `:atoms` - If `true` will encode values and keys.

--- a/lib/ymlr.ex
+++ b/lib/ymlr.ex
@@ -13,10 +13,17 @@ defmodule Ymlr do
 
   Optinally you can pass a tuple with comment(s) and data as first argument.
 
+  ## Options
+
+  - `:atoms` - If `true` will encode values and keys.
+
   ## Examples
 
       iex> Ymlr.document!(%{a: 1})
       "---\\na: 1\\n"
+
+      iex> Ymlr.document!(%{a: 1, b: :c}, atoms: true)
+      "---\\n:a: 1\\n:b: :c\\n"
 
       iex> Ymlr.document!({"comment", %{a: 1}})
       "---\\n# comment\\na: 1\\n"
@@ -27,22 +34,26 @@ defmodule Ymlr do
       iex> Ymlr.document!({[], {"a", "b"}})
       ** (ArgumentError) The given data {\"a\", \"b\"} cannot be converted to YAML.
   """
-  @spec document!(document) :: binary()
-  def document!(document)
-  def document!({lines, data}) when is_list(lines) do
+  @spec document!(document, keyword()) :: binary()
+  def document!(document, opts \\ [])
+  def document!({lines, data}, opts) when is_list(lines) do
     comments = Enum.map_join(lines, "", &("# #{&1}\n"))
-    "---\n" <> comments <> Encoder.to_s!(data) <> "\n"
+    "---\n" <> comments <> Encoder.to_s!(data, opts) <> "\n"
   end
-  def document!({comment, data}), do: document!({[comment], data})
+  def document!({comment, data}, opts), do: document!({[comment], data}, opts)
 
-  def document!(data) do
-    document!({[], data})
+  def document!(data, opts) do
+    document!({[], data}, opts)
   end
 
   @doc """
   Encodes a given data as YAML document with a separator ("---") at the beginning.
 
   Optinally you can pass a tuple with comment(s) and data as first argument.
+
+  ## Options
+
+  - `:atoms` - If `true` will encode values and keys.
 
   ## Examples
 
@@ -52,15 +63,18 @@ defmodule Ymlr do
       iex> Ymlr.document({"comment", %{a: 1}})
       {:ok, "---\\n# comment\\na: 1\\n"}
 
+      iex> Ymlr.document(%{a: 1, b: :c}, atoms: true)
+      {:ok, "---\\n:a: 1\\n:b: :c\\n"}
+
       iex> Ymlr.document({["comment 1", "comment 2"], %{a: 1}})
       {:ok, "---\\n# comment 1\\n# comment 2\\na: 1\\n"}
 
       iex> Ymlr.document({[], {"a", "b"}})
       {:error, "The given data {\\"a\\", \\"b\\"} cannot be converted to YAML."}
   """
-  @spec document(document) :: {:ok, binary()} | {:error, binary()}
-  def document(document) do
-    yml = document!(document)
+  @spec document(document, keyword()) :: {:ok, binary()} | {:error, binary()}
+  def document(document, opts \\ []) do
+    yml = document!(document, opts)
     {:ok, yml}
   rescue
     e in ArgumentError -> {:error, e.message}
@@ -68,6 +82,10 @@ defmodule Ymlr do
 
   @doc """
   Encodes a given list of data as "---" separated YAML documents. Raises if it cannot be encoded.
+
+  ## Options
+
+  - `:atoms` - If `true` will encode values and keys.
 
   ## Examples
 
@@ -77,18 +95,27 @@ defmodule Ymlr do
       iex> Ymlr.documents!([%{a: 1}, %{b: 2}])
       "---\\na: 1\\n\\n---\\nb: 2\\n"
 
+      iex> Ymlr.documents!([%{a: 1, b: :c}, %{d: 2}], atoms: true)
+      "---\\n:a: 1\\n:b: :c\\n\\n---\\n:d: 2\\n"
+
       iex> Ymlr.documents!([{[], {"a", "b"}}])
       ** (ArgumentError) The given data {\"a\", \"b\"} cannot be converted to YAML.
 
       iex> Ymlr.documents!(%{a: "a"})
       ** (ArgumentError) The given argument is not a list of documents. Use document/1, document/2, document!/1 or document!/2 for a single document.
   """
-  def documents!(documents) when is_list(documents), do: Enum.map_join(documents, "\n", &document!/1)
-  def documents!(_documents), do:
+  @spec documents!([document], keyword()) :: binary()
+  def documents!(documents, opts \\ [])
+  def documents!(documents, opts) when is_list(documents), do: Enum.map_join(documents, "\n", &document!(&1, opts))
+  def documents!(_documents, _opts), do:
     raise(ArgumentError, "The given argument is not a list of documents. Use document/1, document/2, document!/1 or document!/2 for a single document.")
 
   @doc """
   Encodes a given list of data as "---" separated YAML documents.
+
+  ## Options
+
+  - `:atoms` - If `true` will encode values and keys.
 
   ## Examples
 
@@ -98,15 +125,18 @@ defmodule Ymlr do
       iex> Ymlr.documents([%{a: 1}, %{b: 2}])
       {:ok, "---\\na: 1\\n\\n---\\nb: 2\\n"}
 
+      iex> Ymlr.documents([%{a: 1, b: :c}, %{d: 2}], atoms: true)
+      {:ok, "---\\n:a: 1\\n:b: :c\\n\\n---\\n:d: 2\\n"}
+
       iex> Ymlr.documents([{[], {"a", "b"}}])
       {:error, "The given data {\\"a\\", \\"b\\"} cannot be converted to YAML."}
 
       iex> Ymlr.documents(%{a: "a"})
       {:error, "The given argument is not a list of documents. Use document/1, document/2, document!/1 or document!/2 for a single document."}
   """
-  @spec documents([document]) :: {:ok, binary()} | {:error, binary()}
-  def documents(documents) do
-    yml = documents!(documents)
+  @spec documents([document], keyword()) :: {:ok, binary()} | {:error, binary()}
+  def documents(documents, opts \\ []) do
+    yml = documents!(documents, opts)
     {:ok, yml}
   rescue
     e in ArgumentError ->

--- a/lib/ymlr/encoder.ex
+++ b/lib/ymlr/encoder.ex
@@ -75,7 +75,7 @@ defmodule Ymlr.Encoder do
   """
   @spec to_s(data, keyword()) :: {:ok, binary()} | {:error, binary()}
   def to_s(data, opts \\ []) do
-    yml = to_s!(data, Enum.into(opts, %{atoms: false}))
+    yml = to_s!(data, opts)
     {:ok, yml}
   rescue
     e in ArgumentError -> {:error, e.message}

--- a/lib/ymlr/encoder_test.exs
+++ b/lib/ymlr/encoder_test.exs
@@ -258,6 +258,27 @@ defmodule Ymlr.EncoderTest do
       assert MUT.to_s!(~D[2016-05-24]) == "2016-05-24"
     end
 
+    test "atoms option" do
+      assert MUT.to_s!(:foo, atoms: true) == ":foo"
+      assert MUT.to_s!(%{"foo" => "bar", baz: :buzz}, atoms: true) == ":baz: :buzz\nfoo: bar"
+    end
+
+    test "nested: map / atoms option" do
+      expected = """
+                 :a: |-
+                   a1
+                   a2
+                 :b: b1
+                 :c: |
+                   c1
+                   c2
+                 :d: d1
+                 :e: :e1
+                 """ |> String.trim()
+
+      assert MUT.to_s!(%{a: "a1\na2", b: "b1", c: "c1\nc2\n", d: "d1", e: :e1}, atoms: true) == expected
+    end
+
     test "datetime" do
       assert MUT.to_s!(~U[2016-05-24 13:26:08Z])      == "2016-05-24T13:26:08Z"
       assert MUT.to_s!(~U[2016-05-24 13:26:08.1Z])    == "2016-05-24T13:26:08.1Z"

--- a/lib/ymlr_test.exs
+++ b/lib/ymlr_test.exs
@@ -10,9 +10,7 @@ defmodule YmlrTest do
     end
 
     test "k8s resource" do
-      {:ok, input} = YamlElixir.read_from_file("test_support/fixtures/iam_policy.yaml")
-
-      output = """
+      expected_output = """
       ---
       apiVersion: iam.cnrm.cloud.google.com/v1beta1
       kind: IAMPolicy
@@ -31,12 +29,14 @@ defmodule YmlrTest do
           name: testing-cc
       """
 
-      assert MUT.document!(input) == output
+      input = YamlElixir.read_from_file!("test_support/fixtures/iam_policy.yaml")
+      output = MUT.document!(input)
+
+      assert output == expected_output
+      assert YamlElixir.read_from_string!(output) |> MUT.document!() == output
     end
 
     test "k8s resource with atoms options" do
-      {:ok, input} = YamlElixir.read_from_file("test_support/fixtures/iam_policy_atoms.yaml", atoms: true)
-
       expected_output = """
       ---
       :apiVersion: iam.cnrm.cloud.google.com/v1beta1
@@ -56,7 +56,11 @@ defmodule YmlrTest do
           :name: testing-cc
       """
 
-      assert MUT.document!(input, atoms: true) == expected_output
+      input = YamlElixir.read_from_file!("test_support/fixtures/iam_policy_atoms.yaml", atoms: true)
+      output = MUT.document!(input, atoms: true)
+
+      assert output == expected_output
+      assert YamlElixir.read_from_string!(output, atoms: true) |> MUT.document!(atoms: true) == output
     end
   end
 end

--- a/lib/ymlr_test.exs
+++ b/lib/ymlr_test.exs
@@ -33,5 +33,30 @@ defmodule YmlrTest do
 
       assert MUT.document!(input) == output
     end
+
+    test "k8s resource with atoms options" do
+      {:ok, input} = YamlElixir.read_from_file("test_support/fixtures/iam_policy_atoms.yaml", atoms: true)
+
+      expected_output = """
+      ---
+      :apiVersion: iam.cnrm.cloud.google.com/v1beta1
+      :kind: :IAMPolicy
+      :metadata:
+        :annotations:
+          :cnrm.cloud.google.com/deletion-policy: abandon
+        :name: sa-testing-cc-iampolicy
+      :spec:
+        :bindings:
+          - :members:
+              - user:test@example.com
+            :role: roles/iam.serviceAccountUser
+        :resourceRef:
+          :apiVersion: iam.cnrm.cloud.google.com/v1beta1
+          :kind: :IAMServiceAccount
+          :name: testing-cc
+      """
+
+      assert MUT.document!(input, atoms: true) == expected_output
+    end
   end
 end

--- a/test_support/fixtures/iam_policy_atoms.yaml
+++ b/test_support/fixtures/iam_policy_atoms.yaml
@@ -1,0 +1,15 @@
+:apiVersion: iam.cnrm.cloud.google.com/v1beta1
+:kind: :IAMPolicy
+:metadata:
+  :annotations:
+    :cnrm.cloud.google.com/deletion-policy: "abandon"
+  :name: sa-testing-cc-iampolicy
+:spec:
+  :resourceRef:
+    :apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    :kind: :IAMServiceAccount
+    :name: testing-cc
+  :bindings:
+    - :members:
+        - user:test@example.com
+      :role: roles/iam.serviceAccountUser


### PR DESCRIPTION
Add option for encoding `atoms` to match [`yaml_elixir`](https://github.com/KamilLelonek/yaml-elixir) library's atom option for decoding.

#### Without option

```elixir
iex> Ymlr.Encoder.to_s!(%{a: 1, b: :c})
"a: 1\\nb: c"
```

#### With option

```elixir
iex> Ymlr.Encoder.to_s!(%{a: 1, b: :c}, atoms: true)
":a: 1\\n:b: :c"
```

#### Requirements

- [x] Entry in CHANGELOG.md was created
-  ~~[ ] Link to documentation on https://yaml.org/ is provided in the PR description~~ N/A
- [x] Functionality is covered by newly created tests
