### PR TITLE
Add support for keyword lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 <!-- Add your changelog entry to the relevant subsection -->
 
-<!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
+### Added
+- Keyword list support
 
 <!--------------------- Don't add new entries after this line --------------------->
 

--- a/lib/ymlr/encoder_test.exs
+++ b/lib/ymlr/encoder_test.exs
@@ -168,6 +168,18 @@ defmodule Ymlr.EncoderTest do
       assert MUT.to_s!(%TestStruct{foo: 1, bar: 2}) == "bar: 2\nfoo: 1"
     end
 
+    test "keyword lists" do
+      assert MUT.to_s!([a: 1]) == "a: 1"
+      assert MUT.to_s!([a: 1, b: 2]) == "a: 1\nb: 2"
+      assert MUT.to_s!([a: nil]) == "a:"
+    end
+    
+    test "invalid keyword key" do
+      assert_raise ArgumentError, fn ->
+        MUT.to_s!([{"a", 1}])
+      end
+    end
+    
     test "nested: list / list" do
       assert MUT.to_s!([[1, 2], [3, 4]]) == "- - 1\n  - 2\n- - 3\n  - 4"
     end


### PR DESCRIPTION
For one of our projects we needed support for keyword lists, so that the key-value pairs would be encoded in the correct order in the YAML output. Currently trying to convert a keyword list will result in an exception. This PR adds a pattern match to `encode_as_io_list` so that keyword lists are encoded in the same way as maps.

---

#### Requirements

- [x] Entry in CHANGELOG.md was created
- [ ] ~Link to documentation on https://yaml.org/ is provided in the PR description~
- [x] Functionality is covered by newly created tests