### PR TITLE
add except: :defaults to @derive

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+
+- `Ymlr.Encoder` - Option `except: :defaults` to exclude default values
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [4.0.0] - 2023-04-16
@@ -23,12 +27,12 @@ for further information.**
 
 ### Changed
 
-* A protocol based implementation was added which give more freedom to users of this library - [#118](https://github.com/ufirstgroup/ymlr/pull/118)
+- A protocol based implementation was added which give more freedom to users of this library - [#118](https://github.com/ufirstgroup/ymlr/pull/118)
 
 ### Added
 
-* Adds an option `atoms` to encode atom map keys with a leading colon.
-* Tuples are now encoded as lists.
+- Adds an option `atoms` to encode atom map keys with a leading colon.
+- Tuples are now encoded as lists.
 
 ## [3.0.1] - 2022-09-05
 

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -191,6 +191,9 @@ defmodule Ymlr.EncodeTest do
       assert "bar: 2\nfoo: 1" == MUT.to_s!(%TestStructDerivedAll{foo: 1, bar: 2})
       assert "foo: 1" == MUT.to_s!(%TestStructDerivedOnlyFoo{foo: 1, bar: 2})
       assert "bar: 2" == MUT.to_s!(%TestStructDerivedExceptFoo{foo: 1, bar: 2})
+
+      assert "baz: error\nfoo: 1" ==
+               MUT.to_s!(%TestStructDerivedExceptDefaults{foo: 1, bar: 1, baz: :error})
     end
 
     test "pids - not supported" do

--- a/test/ymlr/encoder_test.exs
+++ b/test/ymlr/encoder_test.exs
@@ -20,6 +20,11 @@ defmodule Ymlr.EncoderTest do
       @derive {Ymlr.Encoder, except: [:foo]}
       defstruct [:foo, :bar]
     end
+
+    defmodule TestStructDerivedExceptDefaults do
+      @derive {Ymlr.Encoder, except: :defaults}
+      defstruct [:foo, bar: 1, baz: :ok]
+    end
   end
 
   test "Raises if fields don't exist" do

--- a/test_support/structs.ex
+++ b/test_support/structs.ex
@@ -16,3 +16,8 @@ defmodule TestStructDerivedExceptFoo do
   @derive {Ymlr.Encoder, except: [:foo]}
   defstruct [:foo, :bar]
 end
+
+defmodule TestStructDerivedExceptDefaults do
+  @derive {Ymlr.Encoder, except: :defaults}
+  defstruct [:foo, bar: 1, baz: :ok]
+end


### PR DESCRIPTION
Adds the possibility to exclude fields that are left at their defaults by passing `except:  :defaults` to `@derive`:

```elixir
defmodule TestExceptDefaults do
  @derive {Ymlr.Encoder, except: :defaults}
  defstruct [:foo, bar: 1, baz: :ok]
end
```

This would generate an implementation similar to the following:

```elixir
iex> Ymlr.document!(%TestExceptDefaults{foo: 1, bar: 1, baz: :error})
"baz: error\nfoo: 1"
```

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements

- [ ] Entry in CHANGELOG.md was created
- [x] Functionality is covered by newly created tests
