### PR TITLE
Quote values with an initial ":{"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+
+- Quote values beginning with `:{`
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [4.1.0] - 2023-04-23

--- a/lib/ymlr/encode.ex
+++ b/lib/ymlr/encode.ex
@@ -158,6 +158,7 @@ defmodule Ymlr.Encode do
       String.at(data, -1) in @quote_when_last -> with_quotes(data)
       String.starts_with?(data, "- ") -> with_quotes(data)
       String.starts_with?(data, ": ") -> with_quotes(data)
+      String.starts_with?(data, ":{") -> with_quotes(data)
       String.starts_with?(data, "? ") -> with_quotes(data)
       String.contains?(data, " #") -> with_quotes(data)
       String.contains?(data, ": ") -> with_quotes(data)

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -53,6 +53,7 @@ defmodule Ymlr.EncodeTest do
       assert MUT.to_s!("? explicit mapping key") == ~S('? explicit mapping key')
       assert MUT.to_s!("{flow_mapping") == ~S('{flow_mapping')
       assert MUT.to_s!("}flow_mapping") == ~S('}flow_mapping')
+      assert MUT.to_s!(":{ block flow") == ~S(':{ block flow')
       assert MUT.to_s!("[sequence_mapping") == ~S('[sequence_mapping')
       assert MUT.to_s!("]sequence_mapping") == ~S(']sequence_mapping')
 


### PR DESCRIPTION
This combination is parsed as syntax by yamlerl and possibly other decoders, so we should quote when emitting for better compatibility.

Closes #140 .  This is outside of the spec, but makes the output more robust.

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements

- [x] Entry in CHANGELOG.md was created
- [ ] Link to documentation on https://yaml.org/ is provided in the PR description
- [x] Functionality is covered by newly created tests
