### PR TITLE
Sort map by keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Adds an option `sort_maps` to encode map with entries sorted.
 - Quote values beginning with `:{`
 
 <!--------------------- Don't add new entries after this line --------------------->

--- a/README.md
+++ b/README.md
@@ -86,3 +86,29 @@ iex> Ymlr.document!(%{a: 1}, atoms: true)
 :a: 1
 """
 ```
+
+### Encode maps with keys sorted
+Maps in elixir, implemented by erlang `:maps`, internally are `flatmap`s or `hashmap`s by size.
+Large maps will be encoded in strange order.
+
+```elixir
+iex> 1..33 |> Map.new(&{&1, &1})|> Ymlr.document!() |> IO.puts
+---
+4: 4
+25: 25
+8: 8
+...
+
+```
+
+By using `:sort_maps` option, ymlr will encode all entries sorted.
+
+```elixir
+iex> 1..33 |> Map.new(&{&1, &1})|> Ymlr.document!(sort_maps: true) |> IO.puts
+---
+1: 1
+2: 2
+3: 3
+...
+
+```

--- a/lib/ymlr.ex
+++ b/lib/ymlr.ex
@@ -17,6 +17,7 @@ defmodule Ymlr do
   ## Options
 
   * `atoms` - when set to `true`, encodes atom map keys with a leading colon.
+  * `sort_maps` - when set to `true`, sorts map by key-values.
 
   ## Examples
 
@@ -31,6 +32,9 @@ defmodule Ymlr do
 
       iex> Ymlr.document!({["comment 1", "comment 2"], %{a: 1}})
       "---\n# comment 1\n# comment 2\na: 1\n"
+
+      iex> Ymlr.document!(Map.new(1..33, &{&1, &1}), sort_maps: true)
+      "---\n1: 1\n2: 2\n3: 3\n4: 4\n5: 5\n6: 6\n7: 7\n8: 8\n9: 9\n10: 10\n11: 11\n12: 12\n13: 13\n14: 14\n15: 15\n16: 16\n17: 17\n18: 18\n19: 19\n20: 20\n21: 21\n22: 22\n23: 23\n24: 24\n25: 25\n26: 26\n27: 27\n28: 28\n29: 29\n30: 30\n31: 31\n32: 32\n33: 33\n"
   """
   @spec document!(document, opts :: Keyword.t()) :: binary()
   def document!(document, opts \\ [])
@@ -54,6 +58,7 @@ defmodule Ymlr do
   ## Options
 
   * `atoms` - when set to `true`, encodes atom map keys with a leading colon.
+  * `sort_maps` - when set to `true`, sorts map by key-values.
 
   ## Examples
 
@@ -68,6 +73,9 @@ defmodule Ymlr do
 
       iex> Ymlr.document({["comment 1", "comment 2"], %{a: 1}})
       {:ok, "---\n# comment 1\n# comment 2\na: 1\n"}
+
+      iex> Ymlr.document(Map.new(1..33, &{&1, &1}), sort_maps: true)
+      {:ok, "---\n1: 1\n2: 2\n3: 3\n4: 4\n5: 5\n6: 6\n7: 7\n8: 8\n9: 9\n10: 10\n11: 11\n12: 12\n13: 13\n14: 14\n15: 15\n16: 16\n17: 17\n18: 18\n19: 19\n20: 20\n21: 21\n22: 22\n23: 23\n24: 24\n25: 25\n26: 26\n27: 27\n28: 28\n29: 29\n30: 30\n31: 31\n32: 32\n33: 33\n"}
   """
   @spec document(document, opts :: Encoder.opts()) :: {:ok, binary()} | {:error, binary()}
   def document(document, opts \\ []) do
@@ -83,6 +91,7 @@ defmodule Ymlr do
   ## Options
 
   * `atoms` - when set to `true`, encodes atom map keys with a leading colon.
+  * `sort_maps` - when set to `true`, sorts map by key-values.
 
   ## Examples
 
@@ -116,6 +125,7 @@ defmodule Ymlr do
   ## Options
 
   * `atoms` - when set to `true`, encodes atom map keys with a leading colon.
+  * `sort_maps` - when set to `true`, sorts map by key-values.
 
   ## Examples
 

--- a/lib/ymlr/encode.ex
+++ b/lib/ymlr/encode.ex
@@ -81,10 +81,9 @@ defmodule Ymlr.Encode do
   def map(data, indent_level, opts) when is_map(data) do
     indentation = indent(indent_level)
     key_encoder = if opts[:atoms], do: &encode_map_key_atoms/1, else: &encode_map_key/1
+    data = if opts[:sort_maps], do: Enum.sort(data), else: data
 
     data
-    # necessary for maps
-    |> Map.to_list()
     |> Enum.map(fn
       {key, nil} ->
         key_encoder.(key)

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -171,6 +171,10 @@ defmodule Ymlr.EncodeTest do
       assert MUT.to_s!(%{a: nil}, atoms: true) == ":a:"
     end
 
+    test "maps with sort_maps: true" do
+      assert MUT.to_s!(Map.new(1..33, &{&1, &1}), sort_maps: true) |> String.starts_with?("1: 1")
+    end
+
     test "invalid map key" do
       assert_raise ArgumentError, fn ->
         MUT.to_s!(%{%{a: 1} => 2})

--- a/usage.livemd
+++ b/usage.livemd
@@ -292,3 +292,41 @@ simple_2
 ```
 %{message: "nice to be here"}
 ```
+
+## Encode maps with keys sorted
+
+Maps in elixir, implemented by erlang `:maps`, internally are `flatmap`s or `hashmap`s by size.
+Large maps will be encoded in strange order.
+
+```elixir
+map = Map.new(1..33, &{&1, &1})
+map |> Ymlr.document!() |> IO.puts()
+```
+
+<!-- livebook:{"output":true} -->
+
+```
+---
+4: 4
+25: 25
+8: 8
+...
+
+```
+
+By using `:sort_maps` option, ymlr will encode all entries sorted.
+
+```elixir
+map |> Ymlr.document!(sort_maps: true) |> IO.puts()
+```
+
+<!-- livebook:{"output":true} -->
+
+```
+---
+1: 1
+2: 2
+3: 3
+...
+
+```


### PR DESCRIPTION
<!-- Describe your pull request here. Please provide a link to the documentation on yaml.org if applicable !-->
Maps are not sorted when size is over 32.
This pull request sort maps by keys before encoding.
Issue https://github.com/ufirstgroup/ymlr/issues/139


---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements

- [x] Entry in CHANGELOG.md was created
- [ ] Link to documentation on https://yaml.org/ is provided in the PR description
- [x] Functionality is covered by newly created tests
