### PR TITLE
handle "newline only" strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Fixed
+
+- handle "\n" strings - [#157](https://github.com/ufirstgroup/ymlr/issues/157),[#159](https://github.com/ufirstgroup/ymlr/pull/159)
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [4.2.0] - 2023-08-18

--- a/lib/ymlr/encode.ex
+++ b/lib/ymlr/encode.ex
@@ -144,6 +144,7 @@ defmodule Ymlr.Encode do
   defp encode_binary(data, indent_level) do
     cond do
       data == "" -> ~S('')
+      data == "\n" -> ~S("\n")
       data == "null" -> ~S('null')
       data == "yes" -> ~S('yes')
       data == "no" -> ~S('no')

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -280,6 +280,40 @@ defmodule Ymlr.EncodeTest do
       assert MUT.to_s!("hello\nworld\n") == "|\nhello\nworld"
     end
 
+    test "newline only string - encoding" do
+      given = "\n"
+      encoded = MUT.to_s!(given)
+      assert given == YamlElixir.read_from_string!(encoded)
+      assert encoded == ~S("\n")
+    end
+
+    test "newline only string - in list" do
+      given = ["\n"]
+      encoded = MUT.to_s!(given)
+      assert given == YamlElixir.read_from_string!(encoded)
+      assert encoded == ~S(- "\n")
+
+      given = [1, "\n"]
+      encoded = MUT.to_s!(given)
+      assert given == YamlElixir.read_from_string!(encoded)
+
+      given = ["\n", 2]
+      encoded = MUT.to_s!(given)
+      assert given == YamlElixir.read_from_string!(encoded)
+
+      given = [1, "\n", 3]
+      encoded = MUT.to_s!(given)
+      assert given == YamlElixir.read_from_string!(encoded)
+      assert encoded == ~s(- 1\n- "\\n"\n- 3)
+    end
+
+    test "newline only string - in map" do
+      given = %{"a" => "\n"}
+      encoded = MUT.to_s!(given)
+      assert given == YamlElixir.read_from_string!(encoded)
+      assert encoded == ~S(a: "\n")
+    end
+
     # see https://yaml.org/spec/1.2.2/#example-tabs-and-spaces
     test "multiline strings - mix spaces and tabs" do
       given = %{"block" => "void main() {\n\tprintf(\"Hello, world!\\n\");\n}\n"}
@@ -305,7 +339,7 @@ defmodule Ymlr.EncodeTest do
     end
 
     test "nested: map / multiline string" do
-      given = %{"a" => "a1\na2", "b" => "b1", "c" => "c1\nc2\n", "d" => "d1"}
+      given = %{"a" => "a1\na2", "b" => "b1", "c" => "c1\nc2\n", "d" => "d1", "nl" => "\n"}
       encoded = MUT.to_s!(given)
 
       assert YamlElixir.read_from_string!(encoded) == given

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -282,7 +282,8 @@ defmodule Ymlr.EncodeTest do
 
     # see https://yaml.org/spec/1.2.2/#example-tabs-and-spaces
     test "multiline strings - mix spaces and tabs" do
-      given = "void main() {\n\tprintf(\"Hello, world!\\n\");\n}\n"
+      given = %{"block" => "void main() {\n\tprintf(\"Hello, world!\\n\");\n}\n"}
+      encoded = MUT.to_s!(given)
 
       expected =
         """
@@ -293,22 +294,21 @@ defmodule Ymlr.EncodeTest do
         """
         |> String.trim()
 
-      assert MUT.to_s!(%{block: given}) == expected
+      assert encoded == expected
     end
 
     test "nested: list / multiline string" do
-      assert MUT.to_s!(["a\nb\n", "c"]) == "- |\n  a\n  b\n- c"
+      given = ["a\nb\n", "c"]
+      encoded = MUT.to_s!(given)
+
+      assert encoded == "- |\n  a\n  b\n- c"
     end
 
     test "nested: map / multiline string" do
-      result =
-        MUT.to_s!(%{a: "a1\na2", b: "b1", c: "c1\nc2\n", d: "d1"})
-        |> YamlElixir.read_from_string!()
+      given = %{"a" => "a1\na2", "b" => "b1", "c" => "c1\nc2\n", "d" => "d1"}
+      encoded = MUT.to_s!(given)
 
-      assert "a1\na2" == String.trim(result["a"])
-      assert "b1" == result["b"]
-      assert "c1\nc2" == String.trim(result["c"])
-      assert "d1" == result["d"]
+      assert YamlElixir.read_from_string!(encoded) == given
     end
 
     test "date" do

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -326,9 +326,11 @@ defmodule Ymlr.EncodeTest do
           \tprintf("Hello, world!\\n");
           }
         """
-        |> String.trim()
 
-      assert encoded == expected
+      # not working yet => TODO better handling of terminal newlines
+      # assert YamlElixir.read_from_string!(encoded) == given
+      # assert encoded == expected
+      assert encoded == String.trim(expected)
     end
 
     test "nested: list / multiline string" do


### PR DESCRIPTION
Fixes #157

I think "\n" deserves a special case as

```
key: "\n"
next: value
```

feels _prettier_ than

```
key: |+

next: value
```

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements

- [x] Entry in CHANGELOG.md was created
- [ ] Link to documentation on https://yaml.org/ is provided in the PR description
- [x] Functionality is covered by newly created tests
