### PR TITLE
handle inf and nan special floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Support for escape and unicode characters [#98](https://github.com/ufirstgroup/ymlr/pull/98)
-- Refactor `Ymlr.Encode` to make it faster.
+- Refactor `Ymlr.Encode` to make it faster [#171](https://github.com/ufirstgroup/ymlr/pull/171).
+- Handle special floats `.Inf` and `.Nan`. [#170](https://github.com/ufirstgroup/ymlr/issues/170), [#172](https://github.com/ufirstgroup/ymlr/issues/172)
 
 <!--------------------- Don't add new entries after this line --------------------->
 

--- a/lib/ymlr/encode.ex
+++ b/lib/ymlr/encode.ex
@@ -96,8 +96,27 @@ defmodule Ymlr.Encode do
     "? ",
     "0b",
     "0o",
-    "0x"
+    "0x",
+    ".inf",
+    ".Inf",
+    ".INF",
+    "+.inf",
+    "+.Inf",
+    "+.INF",
+    "-.inf",
+    "-.Inf",
+    "-.INF",
+    ".nan",
+    ".Nan",
+    ".NAN"
   ]
+
+  @special_atom_mapping %{
+    :nan => ".nan",
+    :inf => ".inf",
+    :"-inf" => "-.inf",
+    :"+inf" => ".inf"
+  }
 
   @quote_when_contains_string [" #", ": "]
 
@@ -221,6 +240,10 @@ defmodule Ymlr.Encode do
   end
 
   @spec atom(atom()) :: iodata()
+  for {input, encoded} <- @special_atom_mapping do
+    def atom(unquote(input)), do: unquote(encoded)
+  end
+
   def atom(data), do: Atom.to_string(data)
 
   @spec string(binary(), integer) :: iodata()

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -38,6 +38,18 @@ defmodule Ymlr.EncodeTest do
       assert_identity_and_output("0o777", ~S('0o777'))
       assert_identity_and_output("0x1F", ~S('0x1F'))
       assert_identity_and_output("null", ~S('null'))
+      assert_identity_and_output(".inf", ~S('.inf'))
+      assert_identity_and_output(".Inf", ~S('.Inf'))
+      assert_identity_and_output(".INF", ~S('.INF'))
+      assert_identity_and_output("-.inf", ~S('-.inf'))
+      assert_identity_and_output("-.Inf", ~S('-.Inf'))
+      assert_identity_and_output("-.INF", ~S('-.INF'))
+      assert_identity_and_output("+.inf", ~S('+.inf'))
+      assert_identity_and_output("+.Inf", ~S('+.Inf'))
+      assert_identity_and_output("+.INF", ~S('+.INF'))
+      assert_identity_and_output(".nan", ~S('.nan'))
+      assert_identity_and_output(".Nan", ~S('.Nan'))
+      assert_identity_and_output(".NAN", ~S('.NAN'))
     end
 
     test "quoted strings - avoid mapping confusion" do
@@ -196,6 +208,10 @@ defmodule Ymlr.EncodeTest do
 
     test "floats" do
       assert_identity_and_output(1.2, "1.2")
+      assert_identity_and_output(:nan, ".nan")
+      assert_output(:inf, ".inf")
+      assert_identity_and_output(:"+inf", ".inf")
+      assert_identity_and_output(:"-inf", "-.inf")
     end
 
     test "decimals" do


### PR DESCRIPTION
Closes #170 

Implements logic for NAN and INF special floats in YAML.

Docs: https://yaml.org/spec/1.2.2/#10214-floating-point

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements

- [x] Entry in CHANGELOG.md was created
- [x] Link to documentation on https://yaml.org/ is provided in the PR description
- [x] Functionality is covered by newly created tests
