### PR TITLE
Add ? to the list of things to quote when it's an exact value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for escape and unicode characters [#98](https://github.com/ufirstgroup/ymlr/pull/98)
 - Refactor `Ymlr.Encode` to make it faster.
 
+### Fixed
+
+- Put single quotes around '?' when it is the entire value.
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ### Added

--- a/lib/ymlr/encode.ex
+++ b/lib/ymlr/encode.ex
@@ -108,7 +108,6 @@ defmodule Ymlr.Encode do
     "~",
     "?",
     "-",
-    ":",
     "null",
     "yes",
     "no",

--- a/lib/ymlr/encode.ex
+++ b/lib/ymlr/encode.ex
@@ -106,6 +106,7 @@ defmodule Ymlr.Encode do
   @single_quote_when_exact [
     "",
     "~",
+    "?",
     "null",
     "yes",
     "no",

--- a/lib/ymlr/encode.ex
+++ b/lib/ymlr/encode.ex
@@ -107,6 +107,8 @@ defmodule Ymlr.Encode do
     "",
     "~",
     "?",
+    "-",
+    ":",
     "null",
     "yes",
     "no",

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -48,8 +48,31 @@ defmodule Ymlr.EncodeTest do
       assert_identity_and_output("hello #world", ~S('hello #world'))
     end
 
-    test "quoted strings - starts with special char" do
+    test "quoted strings - indicator characters on their own" do
+      assert_identity_and_output("-", ~S('-'))
       assert_identity_and_output("?", ~S('?'))
+      assert_identity_and_output(":", ~S(':'))
+      assert_identity_and_output("[", ~S('['))
+      assert_identity_and_output("]", ~S(']'))
+      assert_identity_and_output("{", ~S('{'))
+      assert_identity_and_output("}", ~S('}'))
+      assert_identity_and_output("#", ~S('#'))
+      assert_identity_and_output("&", ~S('&'))
+      assert_identity_and_output("&", ~S('&'))
+      assert_identity_and_output("*", ~S('*'))
+      assert_identity_and_output("*", ~S('*'))
+      assert_identity_and_output("!", ~S('!'))
+      assert_identity_and_output("!", ~S('!'))
+      assert_identity_and_output("|", ~S('|'))
+      assert_identity_and_output("|", ~S('|'))
+      assert_identity_and_output(">", ~S('>'))
+      assert_identity_and_output(">", ~S('>'))
+      assert_identity_and_output("%", ~S(%))
+      assert_identity_and_output("@", ~S('@'))
+      assert_identity_and_output("`", ~S('`'))
+    end
+    
+    test "quoted strings - starts with special char" do
       assert_identity_and_output("!tag", ~S('!tag'))
       assert_identity_and_output("&anchor", ~S('&anchor'))
       assert_identity_and_output("*alias", ~S('*alias'))

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -18,6 +18,14 @@ defmodule Ymlr.EncodeTest do
     test "plain strings" do
       assert_identity_and_output("hello world", "hello world")
       assert_identity_and_output("that's it", "that's it")
+
+      # Strings where the ":", "?", or "-" indicator character is used as the
+      # first character may be encoded in Plain Style (without being quoted)
+      # if followed by a non-space “safe” character.
+      # https://yaml.org/spec/1.2.2/#733-plain-style
+      assert_identity_and_output("?x", ~S(?x))
+      assert_identity_and_output(":x", ~S(:x))
+      assert_identity_and_output("-x", ~S(-x))
     end
 
     # see http://blogs.perl.org/users/tinita/2018/03/strings-in-yaml---to-quote-or-not-to-quote.html
@@ -71,7 +79,7 @@ defmodule Ymlr.EncodeTest do
       assert_identity_and_output("@", ~S('@'))
       assert_identity_and_output("`", ~S('`'))
     end
-    
+
     test "quoted strings - starts with special char" do
       assert_identity_and_output("!tag", ~S('!tag'))
       assert_identity_and_output("&anchor", ~S('&anchor'))

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -49,6 +49,7 @@ defmodule Ymlr.EncodeTest do
     end
 
     test "quoted strings - starts with special char" do
+      assert_identity_and_output("?", ~S('?'))
       assert_identity_and_output("!tag", ~S('!tag'))
       assert_identity_and_output("&anchor", ~S('&anchor'))
       assert_identity_and_output("*alias", ~S('*alias'))


### PR DESCRIPTION
<!-- Describe your pull request here. Please provide a link to the documentation on yaml.org if applicable !-->
Closes #177 

The linked issue includes the full description of the problem this resolves, with reproduction, and notes from the YAML spec. The particularly relevant sections of the spec are:

- [5.3](https://yaml.org/spec/1.2.2/#53-indicator-characters) - the `?` character is used as an `indicator` character, indicating a mapping key
- [7.3.3](https://yaml.org/spec/1.2.2/#733-plain-style) - the `?` character can only be encoded in Plain Style when it's followed by a non-space "safe" character.

The proposed fix is to add `?` to the list of values already being considered for quotation when they appear as exact values.

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements

- [x] Entry in CHANGELOG.md was created
- [x] Link to documentation on https://yaml.org/ is provided in the PR description
- [x] Functionality is covered by newly created tests
