### PR TITLE
Also escape %

### DIFF
--- a/lib/ymlr/encode.ex
+++ b/lib/ymlr/encode.ex
@@ -94,6 +94,7 @@ defmodule Ymlr.Encode do
     "- ",
     ": ",
     ":{",
+    "%",
     "? ",
     "0b",
     "0o",

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -102,7 +102,7 @@ defmodule Ymlr.EncodeTest do
       assert_identity_and_output("|", ~S('|'))
       assert_identity_and_output(">", ~S('>'))
       assert_identity_and_output(">", ~S('>'))
-      assert_identity_and_output("%", ~S(%))
+      assert_identity_and_output("%", ~S('%'))
       assert_identity_and_output("@", ~S('@'))
       assert_identity_and_output("`", ~S('`'))
     end


### PR DESCRIPTION
Not sure if rails uses a different yml standard, but I tried writing i18n locale files for a rails application and got this error:
```
/usr/local/bundle/gems/i18n-1.14.1/lib/i18n/backend/base.rb:259:in `rescue in load_yml': can not load translations from ./config/locales/de.yml: #<Psych::SyntaxError: (./config/locales/de.yml): found character that cannot start any token while scanning for the next token at line 574 column 16> (I18n::InvalidLocaleData)
```

For this line:
```
default: %d.%m.%Y
```

When it's quoted it works.

Not sure if it makes sense to include here and if it's actually correct. I tried scanning the standard but not really sure where to look. I found `%` under directives, but I don't know if it actually has a special meaning for values as well.

---

#### Requirements

- [ ] Entry in CHANGELOG.md was created
- [ ] Link to documentation on https://yaml.org/ is provided in the PR description
- [ ] Functionality is covered by newly created tests
