### PR TITLE
keep date, time, on the same line when in a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Changed
+
+- Changed how Date, Time, NaiveDateTime, and DateTime are encode when nested in a map, fixes [#207](https://github.com/ufirstgroup/ymlr/issues/207)
+
 ### Fixed
 
 - fixed typo in spec: `idnent_level` => `indent_level`

--- a/lib/ymlr/encode.ex
+++ b/lib/ymlr/encode.ex
@@ -234,6 +234,18 @@ defmodule Ymlr.Encode do
       {key, value} when value == %{} ->
         [key_encoder.(key), " {}"]
 
+      {key, value} when is_struct(value, Date) ->
+        [key_encoder.(key), " " | Encoder.encode(value, indent_level, opts)]
+
+      {key, value} when is_struct(value, Time) ->
+        [key_encoder.(key), " " | Encoder.encode(value, indent_level, opts)]
+
+      {key, value} when is_struct(value, NaiveDateTime) ->
+        [key_encoder.(key), " " | Encoder.encode(value, indent_level, opts)]
+
+      {key, value} when is_struct(value, DateTime) ->
+        [key_encoder.(key), " " | Encoder.encode(value, indent_level, opts)]
+
       {key, value} when is_map(value) ->
         [key_encoder.(key), indentation, "  " | Encoder.encode(value, indent_level + 1, opts)]
 

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -571,6 +571,35 @@ defmodule Ymlr.EncodeTest do
       assert_output(~D[2016-05-24], "2016-05-24")
     end
 
+    test "date in map" do
+      assert_output(%{"d" => ~D[2016-05-24]}, "d: 2016-05-24")
+    end
+
+    test "date in list" do
+      assert_output([1, ~D[2016-05-24]], "- 1\n- 2016-05-24")
+    end
+
+    test "time" do
+      assert_output(~T[23:22:21], "23:22:21")
+      assert_output(~T[23:22:21.20], "23:22:21.20")
+    end
+
+    test "time in map" do
+      assert_output(%{"t" => ~T[01:02:03]}, "t: 01:02:03")
+    end
+
+    test "naivedatetime" do
+      assert_output(~N[2016-05-24 23:22:21], "2016-05-24T23:22:21")
+      assert_output(~N[2016-05-24 23:22:21.0], "2016-05-24T23:22:21.0")
+      assert_output(~N[2016-05-24 23:22:21.00], "2016-05-24T23:22:21.00")
+      assert_output(~N[2016-05-24 23:22:21.000], "2016-05-24T23:22:21.000")
+      assert_output(~N[2016-05-24 23:22:21.0000], "2016-05-24T23:22:21.0000")
+    end
+
+    test "naivedatetime in map" do
+      assert_output(%{"ts" => ~N[2016-05-24 13:26:08]}, "ts: 2016-05-24T13:26:08")
+    end
+
     test "datetime" do
       assert_output(~U[2016-05-24 13:26:08Z], "2016-05-24T13:26:08Z")
       assert_output(~U[2016-05-24 13:26:08.1Z], "2016-05-24T13:26:08.1Z")
@@ -578,5 +607,10 @@ defmodule Ymlr.EncodeTest do
       assert_output(~U[2016-05-24 13:26:08.003Z], "2016-05-24T13:26:08.003Z")
       assert_output(~U[2016-05-24 13:26:08.0004Z], "2016-05-24T13:26:08.0004Z")
     end
+
+    test "datetime in map" do
+      assert_output(%{"ts" => ~U[2016-05-24 13:26:08Z]}, "ts: 2016-05-24T13:26:08Z")
+    end
+
   end
 end

--- a/test/ymlr/encode_test.exs
+++ b/test/ymlr/encode_test.exs
@@ -611,6 +611,5 @@ defmodule Ymlr.EncodeTest do
     test "datetime in map" do
       assert_output(%{"ts" => ~U[2016-05-24 13:26:08Z]}, "ts: 2016-05-24T13:26:08Z")
     end
-
   end
 end


### PR DESCRIPTION
keep date, time, on the same line when in a map, fixes #207 

#### Requirements

- [x] Entry in CHANGELOG.md was created
- [x] Functionality is covered by newly created tests
